### PR TITLE
feat(pretty) add a debug function to quickly dump some values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### New features
+
+  - `pretty.debug` quickly dumps a set of values to stdout for debug purposes
+
 ### Changes
 
   - `pretty.write`: now also sorts non-string keys [#319](https://github.com/Tieske/Penlight/pull/319)

--- a/lua/pl/pretty.lua
+++ b/lua/pl/pretty.lua
@@ -315,6 +315,49 @@ function pretty.dump (t, filename)
     end
 end
 
+--- Dump a series of arguments to stdout for debug purposes.
+-- This function is attached to the module table `__call` method, to make it
+-- extra easy to access. So the full:
+--
+--     print(require("pl.pretty").write({...}))
+--
+-- Can be shortened to:
+--
+--     require"pl.pretty" (...)
+--
+-- Any `nil` entries will be printed as `"<nil>"` to make them explicit.
+-- @param ... the parameters to dump to stdout.
+-- @usage
+-- -- example debug output
+-- require"pl.pretty" ("hello", nil, "world", { bye = "world", true} )
+--
+-- -- output:
+-- {
+--   ["arg 1"] = "hello",
+--   ["arg 2"] = "<nil>",
+--   ["arg 3"] = "world",
+--   ["arg 4"] = {
+--     true,
+--     bye = "world"
+--   }
+-- }
+function pretty.debug(...)
+    local n = select("#", ...)
+    local t = { ... }
+    for i = 1, n do
+        local value = t[i]
+        if value == nil then
+            value = "<nil>"
+        end
+        t[i] = nil
+        t["arg " .. i] = value
+    end
+
+    print(pretty.write(t))
+    return true
+end
+
+
 local memp,nump = {'B','KiB','MiB','GiB'},{'','K','M','B'}
 
 local function comma (val)
@@ -358,4 +401,8 @@ function pretty.number (num,kind,prec)
     end
 end
 
-return pretty
+return setmetatable(pretty, {
+    __call = function(self, ...)
+        return self.debug(...)
+    end
+})


### PR DESCRIPTION
The call should be as short as possible to make it quick to use.
The idea is to create a call that is self contained (without
previous declared locals and require statements), such that we do
not accidentally leave references behind.

example:

```lua
require"pl.pretty" (...)
```

currently this would require:

```lua
print(require("pl.pretty").write({...}))
```