### PR TITLE
pl.pretty: fix table write with symbol as key

### DIFF
--- a/lua/pl/pretty.lua
+++ b/lua/pl/pretty.lua
@@ -254,7 +254,12 @@ function pretty.write (tbl,space,not_clever)
                   ordered_keys[#ordered_keys + 1] = k
                end
             end
-            table.sort(ordered_keys)
+            table.sort(ordered_keys, function (a, b)
+                if type(a) == type(b)  and type(a) == 'string' then
+                    return a < b
+                end
+                return type(a) == 'boolean' or (type(b) ~= 'boolean' and type(a) == 'table')
+            end)
             local function write_entry (key, val)
                 local tkey = type(key)
                 local numkey = tkey == 'number'

--- a/tests/test-pretty.lua
+++ b/tests/test-pretty.lua
@@ -84,6 +84,12 @@ t2 = {}
 t1[1],t1[2] = t2,t2
 asserteq( pretty.write(t1,""), [[{{},{}}]] )
 
+-- Check that write correctly print table with non number or string as keys
+
+t1 = { [true] = "boolean", a = "a", b = "b", [1] = 1, [0] = 0 }
+asserteq( pretty.write(t1,""), [[{1,["true"]="boolean",a="a",b="b",[0]=0}]] )
+
+
 -- Check number formatting
 asserteq(pretty.write({1/0, -1/0, 0/0, 1, 1/2}, ""), "{Inf,-Inf,NaN,1,0.5}")
 


### PR DESCRIPTION
Table keys ordering has been introduce with commit 9aecd3f. Unfortunately
a table sort is apply on all keys, but sort with default comparator is
unable to sort table containing different value types like boolean or table.

A solution is to introduce a custom comparator.
With it keys are now in the following order:
- ordered number
- symbols
- sorted strings
- unorder numbers