### PR TITLE
docs(tablex) find_if cmp function cannot return false

### DIFF
--- a/docs/libraries/pl.tablex.html
+++ b/docs/libraries/pl.tablex.html
@@ -1225,7 +1225,7 @@
         </li>
         <li><span class="parameter">cmp</span>
             <span class="types"><span class="type">func</span></span>
-         A comparison function
+         A comparison function returning a non-false value on success
         </li>
         <li><span class="parameter">arg</span>
          an optional second argument to the function


### PR DESCRIPTION
Hi,
The docs about "tablex.find_if()" leave an ambiguity: it is not specified the comparison function cannot return "false" for processing by the caller (it is implied that it should return something).
In reality, we return values only if the comparison function returns a non-nil (obvious) but also non-false (less obvious) value.