### PR TITLE
fix Openresty coroutine usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root                     = true
+
+[*]
+end_of_line              = lf
+insert_final_newline     = true
+trim_trailing_whitespace = true
+charset                  = utf-8
+
+[*.lua]
+indent_style             = space
+indent_size              = 2
+
+[kong/templates/nginx*]
+indent_style             = space
+indent_size              = 4
+
+[*.template]
+indent_style             = space
+indent_size              = 4
+
+[Makefile]
+indent_style             = tab

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,6 +2,13 @@ unused_args     = false
 redefined       = false
 max_line_length = false
 
+globals = {
+    "ngx",
+    "coroutine._wrap",
+    "coroutine._yield",
+    "coroutine._create",
+    "coroutine._resume",
+}
 
 not_globals = {
     "string.len",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@
     [#326](https://github.com/Tieske/Penlight/pull/326)
   - added an extra changelog entry for `types.is_empty` on the 1.6.0 changelog, due
     to additional fixed behaviour not called out appropriately [#313](https://github.com/Tieske/Penlight/pull/313)
+  - `path.packagepath` now returns a proper error message with names tried if
+    it fails
 
 ### Fixes
 
   - Fix: `stringx.rfind` now properly works with overlapping matches
     [#314](https://github.com/Tieske/Penlight/pull/314)
+  - Fix: `package.searchpath` (in module `pl.compat`)
+    [#328](https://github.com/Tieske/Penlight/pull/328)
 
 ## 1.7.0 (2019-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
     [#314](https://github.com/Tieske/Penlight/pull/314)
   - Fix: `package.searchpath` (in module `pl.compat`)
     [#328](https://github.com/Tieske/Penlight/pull/328)
+  - Fix: OpenResty coroutines, used by `dir.dirtree`, `pl.lexer`, `pl.permute`. If
+    available the original coroutine functions are now used [#329](https://github.com/Tieske/Penlight/pull/329)
 
 ## 1.7.0 (2019-10-14)
 

--- a/lua/pl/dir.lua
+++ b/lua/pl/dir.lua
@@ -15,9 +15,12 @@ local sub = string.sub
 local os,pcall,ipairs,pairs,require,setmetatable = os,pcall,ipairs,pairs,require,setmetatable
 local remove = os.remove
 local append = table.insert
-local wrap = coroutine.wrap
-local yield = coroutine.yield
 local assert_arg,assert_string,raise = utils.assert_arg,utils.assert_string,utils.raise
+
+-- check on OpenResty coroutine versions, and use originals if possible
+local wrap = coroutine._wrap or coroutine.wrap
+local yield = coroutine._yield or coroutine.yield
+
 
 local dir = {}
 

--- a/lua/pl/lexer.lua
+++ b/lua/pl/lexer.lua
@@ -20,10 +20,14 @@
 -- See the Guide for further @{06-data.md.Lexical_Scanning|discussion}
 -- @module pl.lexer
 
-local yield,wrap = coroutine.yield,coroutine.wrap
 local strfind = string.find
 local strsub = string.sub
 local append = table.insert
+
+-- check on OpenResty coroutine versions, and use originals if possible
+local wrap = coroutine._wrap or coroutine.wrap
+local yield = coroutine._yield or coroutine.yield
+
 
 local function assert_arg(idx,val,tp)
     if type(val) ~= tp then

--- a/lua/pl/permute.lua
+++ b/lua/pl/permute.lua
@@ -6,9 +6,12 @@ local tablex = require 'pl.tablex'
 local utils = require 'pl.utils'
 local copy = tablex.deepcopy
 local append = table.insert
-local coroutine = coroutine
-local resume = coroutine.resume
 local assert_arg = utils.assert_arg
+
+-- check on OpenResty coroutine versions, and use originals if possible
+local co_create = coroutine._create or coroutine.create
+local co_yield = coroutine._yield or coroutine.yield
+local co_resume = coroutine._resume or coroutine.resume
 
 
 local permute = {}
@@ -41,9 +44,9 @@ end
 function permute.iter (a)
     assert_arg(1,a,'table')
     local n = #a
-    local co = coroutine.create(function () permgen(a, n, coroutine.yield) end)
+    local co = co_create(function () permgen(a, n, co_yield) end)
     return function ()   -- iterator
-        local _, res = resume(co)
+        local _, res = co_resume(co)
         return res
     end
 end


### PR DESCRIPTION
OpenResty coroutines break Lua paradigms and hence can break in regular Lua code. The code now tries to detect if the original version are available and then uses those.

Fixes #265