### PR TITLE
fix(strict) minor fixes to strict module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
     [#328](https://github.com/Tieske/Penlight/pull/328)
   - Fix: OpenResty coroutines, used by `dir.dirtree`, `pl.lexer`, `pl.permute`. If
     available the original coroutine functions are now used [#329](https://github.com/Tieske/Penlight/pull/329)
+  - Fix: in `pl.strict` also predefine global `_PROMPT2`
+  - Fix: in `pl.strict` apply `tostring` to the given name, in case it is not a string.
 
 ## 1.7.0 (2019-10-14)
 

--- a/lua/pl/strict.lua
+++ b/lua/pl/strict.lua
@@ -1,7 +1,7 @@
 --- Checks uses of undeclared global variables.
 -- All global variables must be 'declared' through a regular assignment
 -- (even assigning `nil` will do) in a main chunk before being used
--- anywhere or assigned to inside a function.  Existing metatables `__newindex` and `__index`
+-- anywhere or assigned to inside a function. Existing metatables `__newindex` and `__index`
 -- metamethods are respected.
 --
 -- You can set any table to have strict behaviour using `strict.module`. Creating a new
@@ -23,10 +23,21 @@ local function what ()
 end
 
 --- make an existing table strict.
--- @string name name of table (optional)
--- @tab[opt] mod table - if `nil` then we'll return a new table
+-- @string[opt] name name of table
+-- @tab[opt] mod the table to protect - if `nil` then we'll return a new table
 -- @tab[opt] predeclared - table of variables that are to be considered predeclared.
 -- @return the given table, or a new table
+-- @usage
+-- local M = { hello = "world" }
+-- strict.module ("Awesome_Module", M, {
+--   Lua = true,  -- defines allowed keys
+-- })
+--
+-- assert(M.hello == "world")
+-- assert(M.Lua == nil)       -- access allowed, but has no value yet
+-- M.Lua = "Rocks"
+-- assert(M.Lua == "Rocks")
+-- M.not_allowed = "bad boy"  -- throws an error
 function strict.module (name,mod,predeclared)
     local mt, old_newindex, old_index, old_index_type, global
     if predeclared then
@@ -80,7 +91,7 @@ function strict.module (name,mod,predeclared)
             end
             local msg = "variable '"..n.."' is not declared"
             if name then
-                msg = msg .. " in '"..name.."'"
+                msg = msg .. " in '"..tostring(name).."'"
             end
             error(msg, 2)
         end
@@ -92,7 +103,7 @@ end
 --- make all tables in a table strict.
 -- So `strict.make_all_strict(_G)` prevents monkey-patching
 -- of any global table
--- @tab T
+-- @tab T the table containing the tables to protect. Table `T` itself will NOT be protected.
 function strict.make_all_strict (T)
     for k,v in pairs(T) do
         if type(v) == 'table' and v ~= T then
@@ -103,6 +114,8 @@ end
 
 --- make a new module table which is closed to further changes.
 function strict.closed_module (mod,name)
+    -- No clue to what this is useful for? see tests
+    -- Deprecate this and remove???
     local M = {}
     mod = mod or {}
     local mt = getmetatable(mod)
@@ -117,8 +130,7 @@ function strict.closed_module (mod,name)
 end
 
 if not rawget(_G,'PENLIGHT_NO_GLOBAL_STRICT') then
-    strict.module(nil,_G,{_PROMPT=true,__global=true})
+    strict.module(nil,_G,{_PROMPT=true,_PROMPT2=true,__global=true})
 end
 
 return strict
-


### PR DESCRIPTION
1. predefine "_PROMPT2" besides just "_PROMPT"
2. tostring the name before concatenating

also adds docs an examples