### PR TITLE
chore(ci) add CI support for Lua 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ before_install:
   - pip install hererocks
   - hererocks here -r^ --$LUA
   - source here/bin/activate
-  - if [[ ! "$LUA" == "lua 5.4" ]]; then luarocks install luacheck; fi
+  - luarocks install luacheck
+  - luarocks install luacov-coveralls
 
 install:
   - luarocks make
-  - luarocks install luacov-coveralls
 
 script:
-  - if [[ ! "$LUA" == "lua 5.4" ]]; then luacheck .; fi
-  - if [[ ! "$LUA" == "lua 5.4" ]]; then lua run.lua tests --luacov; else lua run.lua tests; fi
+  - luacheck .
+  - lua run.lua tests --luacov
 
 after_success:
-  - if [[ ! "$LUA" == "lua 5.4" ]]; then luacov-coveralls; fi
+  - luacov-coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,23 +18,19 @@ before_build:
   - pip install hererocks
   - hererocks here --%LUA% -rlatest
   - call here\bin\activate
+  - luarocks install luacheck
+  - "if \"%LUA%\"==\"lua 5.4\" ( luarocks install bit32 )"
   - luarocks install luacov-coveralls
 
 build_script:
   - luarocks make
 
 test_script:
-  # LuaCov not yet compatible with Lua 5.4
-  - "if \"%LUA%\"==\"lua 5.4\" (
-      lua run.lua tests
-    ) else (
-      lua run.lua tests --luacov
-    )"
+  - luacheck .
+  - lua run.lua tests --luacov
 
 on_success:
   # secure coveralls token not available on PR builds, only BRANCH builds
   - "if not \"%COVERALLS_REPO_TOKEN%\"==\"\" (
-       if not \"%LUA%\"==\"lua 5.4\" (
-         luacov-coveralls
-       )
+       luacov-coveralls
     )"


### PR DESCRIPTION
there is a workaround for the "bit32" library, see https://github.com/moteus/luacov-coveralls/issues/26
